### PR TITLE
feat: add file transcription CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,18 @@ else
 	go build $(UI_TAGS) -o $(BUILD_DIR)/$(APP_NAME) ./$(CMD_DIR)
 endif
 
+# Build transcribe CLI (no UI dependencies)
+build-transcribe: deps
+	@echo "Building transcribe..."
+	@mkdir -p $(BUILD_DIR)
+ifeq ($(UNAME_S),Darwin)
+	CGO_LDFLAGS="$(BASE_LDFLAGS) -framework Accelerate -framework Foundation" \
+	go build -o $(BUILD_DIR)/transcribe ./cmd/transcribe
+else
+	CGO_LDFLAGS="$(BASE_LDFLAGS)" \
+	go build -o $(BUILD_DIR)/transcribe ./cmd/transcribe
+endif
+
 run: build
 	@echo "Running $(APP_NAME)..."
 	@./$(BUILD_DIR)/$(APP_NAME)

--- a/cmd/transcribe/main.go
+++ b/cmd/transcribe/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+
+	"github.com/cesp99/sussurro/internal/asr"
+	"github.com/cesp99/sussurro/internal/config"
+	"github.com/cesp99/sussurro/internal/llm"
+	"github.com/cesp99/sussurro/internal/logger"
+)
+
+func main() {
+	inputFile := flag.String("i", "", "Input audio file (any format ffmpeg supports)")
+	outputFile := flag.String("o", "", "Output text file (default: stdout)")
+	configPath := flag.String("config", "", "Path to configuration file")
+	clean := flag.Bool("clean", false, "Run LLM cleanup on transcription")
+	language := flag.String("lang", "", "Override ASR language (e.g. en, auto)")
+	debug := flag.Bool("debug", false, "Enable debug output")
+	flag.Parse()
+
+	if *inputFile == "" {
+		fmt.Fprintln(os.Stderr, "Usage: transcribe -i <audio-file> [-o output.txt] [-clean] [-lang en] [-config path]")
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(*inputFile); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: input file not found: %s\n", *inputFile)
+		os.Exit(1)
+	}
+
+	// Load config
+	cfg, err := config.LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *debug {
+		logger.Init("debug")
+	} else {
+		logger.Init(cfg.App.LogLevel)
+	}
+
+	// Convert audio to 16kHz mono f32le PCM via ffmpeg
+	samples, err := audioToSamples(*inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to decode audio: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(samples) == 0 {
+		fmt.Fprintln(os.Stderr, "Error: no audio samples decoded")
+		os.Exit(1)
+	}
+
+	// Determine language
+	lang := cfg.Models.ASR.Language
+	if *language != "" {
+		lang = *language
+	}
+
+	// Initialize ASR engine
+	asrEngine, err := asr.NewEngine(cfg.Models.ASR.Path, cfg.Models.ASR.Threads, lang, *debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to initialize ASR engine: %v\n", err)
+		os.Exit(1)
+	}
+	defer asrEngine.Close()
+
+	// Transcribe
+	text, err := asrEngine.Transcribe(samples)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: transcription failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Optional LLM cleanup
+	if *clean {
+		llmEngine, err := llm.NewEngine(cfg.Models.LLM.Path, cfg.Models.LLM.Threads, cfg.Models.LLM.ContextSize, cfg.Models.LLM.GpuLayers, *debug)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to initialize LLM engine: %v\n", err)
+			os.Exit(1)
+		}
+		defer llmEngine.Close()
+
+		cleaned, err := llmEngine.CleanupText(text)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: LLM cleanup failed, using raw transcription: %v\n", err)
+		} else {
+			text = cleaned
+		}
+	}
+
+	// Output
+	if *outputFile != "" {
+		if err := os.WriteFile(*outputFile, []byte(text+"\n"), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to write output file: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Transcription written to %s\n", *outputFile)
+	} else {
+		fmt.Println(text)
+	}
+}
+
+// audioToSamples converts any audio file to 16kHz mono float32 samples using ffmpeg.
+func audioToSamples(path string) ([]float32, error) {
+	cmd := exec.Command("ffmpeg",
+		"-i", path,
+		"-f", "f32le",
+		"-ar", "16000",
+		"-ac", "1",
+		"-loglevel", "error",
+		"pipe:1",
+	)
+	cmd.Stderr = os.Stderr
+
+	raw, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffmpeg failed: %w (is ffmpeg installed?)", err)
+	}
+
+	numSamples := len(raw) / 4
+	samples := make([]float32, numSamples)
+	for i := range samples {
+		bits := binary.LittleEndian.Uint32(raw[i*4:])
+		samples[i] = math.Float32frombits(bits)
+	}
+
+	return samples, nil
+}


### PR DESCRIPTION
## Summary
- Add a standalone `transcribe` command (`cmd/transcribe/main.go`) that transcribes audio files to text using the existing Whisper ASR engine
- Supports any audio format via ffmpeg (mp3, m4a, wav, flac, etc.)
- Optional LLM cleanup pass with `-clean` flag
- Add `make build-transcribe` Makefile target (no UI dependencies required)

## Usage
```bash
make build-transcribe
./bin/transcribe -i recording.mp3 -o output.txt
./bin/transcribe -i recording.m4a -clean -lang auto
```

## Test plan
- [x] Build with `make build-transcribe` on Linux
- [x] Transcribe an M4A file successfully
- [x] Test on macOS
- [x] Test with `-clean` flag (requires LLM model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)